### PR TITLE
Change python-test.yml to pass on docs-only

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,10 +8,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md' # Only in the topmost directory
-      - 'LICENSE'
     
 
 jobs:
@@ -21,11 +17,32 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
+    # Use changed-files-specific action to collect file changes.
+    # The following commented condition applied to a step will run that step only if non-docs files have changed.
+    # It should be applied to all functionality-related steps.
+    # if: steps.changed-files-specific.outputs.only_modified == 'false'
+    - name: Detect and screen file changes
+      id: changed-files-specific
+      uses: tj-actions/changed-files@v34
+      with:
+          files: |
+            docs/**
+            *.md
+            LICENSE
+
+    - name: Summarize docs and non-docs modifications
+      run: |
+        echo "List of docs files that have changed: ${{ steps.changed-files-specific.outputs.all_modified_files }}"
+        echo "Changed non-docs files: ${{ steps.changed-files-specific.outputs.other_modified_files }}"
+    
     - name: Set up Python 3.8
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies and package
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       run: |
         sudo apt-get install libvips libvips-tools -y
         python -m pip install --upgrade pip
@@ -34,26 +51,33 @@ jobs:
         pip install torch==1.11.0+cpu torchvision==0.12.0+cpu torchaudio==0.11.0 --extra-index-url https://download.pytorch.org/whl/cpu
         pip install -e .
     - name: Run generic unit tests
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       run: |
         pytest --cov=. --cov-report=xml -k "generic"        
     - name: Run classification unit tests with histology
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       run: |
         pytest --cov=. --cov-report=xml --cov-append -k "classification and histology"
     - name: Run classification unit tests
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       run: |
         pytest --cov=. --cov-report=xml --cov-append -k "classification and not histology"
     - name: Run regression unit tests
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       run: |
         pytest --cov=. --cov-report=xml --cov-append -k "regression"
     - name: Run segmentation unit tests
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       run: |
         pytest --cov=. --cov-report=xml --cov-append -k "segmentation and not transunet"
     - name: Run transunet unit tests
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       run: |
         pytest --cov=. --cov-report=xml --cov-append -k "transunet"
 
 
     - name: Upload coverage
+      if: steps.changed-files-specific.outputs.only_modified == 'false' # Run on any non-docs change
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixes #516 

## Proposed Changes

- Changes the CI workflow file python-test.yml to skip testing / coverage report steps instead of skipping the entire build job. This will allow branch protection to still work with docs-only PRs

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GaNDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change 
- [x] Function/class source code documentation added/updated
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency
- [x] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/mlcommons/GaNDLF/blob/master/GANDLF/version.py)
- [x] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/mlcommons/GaNDLF/blob/master/pyproject.toml) file 
- [ ] [Usage documentation](https://github.com/mlcommons/GaNDLF/blob/master/docs) has been updated, if appropriate
- [ ] [History](https://github.com/mlcommons/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [ ] Tests added or modified to [cover the changes](https://app.codecov.io/gh/mlcommons/GaNDLF); if coverage is reduced, please give explanation
- [ ] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/mlcommons/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CUDA10.2),[3](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CUDA11.3),[4](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-ROCm)] 
