### PR TITLE
chore: move coverage configuration to `pyproject.toml`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,0 @@
-[run] 
-source = ./GANDLF
-omit = 
-    ./setup.py
-    ./GANDLF/anonymize/slide_anonymizer.py
-    ./testing/conftest.py
-    ./gandlf_*
-    .github/*
-    .devcontainer/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,14 @@ extend-exclude = '''
   | .*.md
 )/
 '''
+
+[tool.coverage.run]
+source = ["./GANDLF"]
+omit = [
+  "./setup.py",
+  "./GANDLF/anonymize/slide_anonymizer.py",
+  "./testing/conftest.py",
+  "./gandlf_*",
+  ".github/*",
+  ".devcontainer/*",
+]


### PR DESCRIPTION
## Proposed Changes

This PR aims to move the `coverage` configuration from a separate `.coveragerc` file to `pyproject.toml`. Doing this leads to a minimal project structure without any functional change
 
## Checklist

- [x] I have read the [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide.
- [x] My PR is based from the [current GaNDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/).
- [x] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change.

