### PR TITLE
Use torchmetric PSNR implementation and argument ordering

### DIFF
--- a/GANDLF/metrics/synthesis.py
+++ b/GANDLF/metrics/synthesis.py
@@ -8,6 +8,7 @@ from torchmetrics import (
     MeanSquaredError,
     MeanSquaredLogError,
     MeanAbsoluteError,
+    PeakSignalNoiseRatio,
 )
 from GANDLF.utils import get_image_from_tensor
 
@@ -25,7 +26,7 @@ def structural_similarity_index(target, prediction, mask=None) -> torch.Tensor:
         torch.Tensor: The structural similarity index.
     """
     ssim = StructuralSimilarityIndexMeasure(return_full_image=True)
-    _, ssim_idx_full_image = ssim(target, prediction)
+    _, ssim_idx_full_image = ssim(preds=prediction, target=target)
     mask = torch.ones_like(ssim_idx_full_image) if mask is None else mask
     try:
         ssim_idx = ssim_idx_full_image[mask]
@@ -45,7 +46,7 @@ def mean_squared_error(target, prediction) -> torch.Tensor:
         prediction (torch.Tensor): The prediction tensor.
     """
     mse = MeanSquaredError()
-    return mse(target, prediction)
+    return mse(preds=prediction, target=target)
 
 
 def peak_signal_noise_ratio(target, prediction) -> torch.Tensor:
@@ -56,12 +57,8 @@ def peak_signal_noise_ratio(target, prediction) -> torch.Tensor:
         target (torch.Tensor): The target tensor.
         prediction (torch.Tensor): The prediction tensor.
     """
-    mse = mean_squared_error(target, prediction)
-    return (
-        10.0
-        * torch.log10((torch.max(target) - torch.min(target)) ** 2)
-        / (mse + sys.float_info.epsilon)
-    )
+    psnr = PeakSignalNoiseRatio()
+    return psnr(preds=prediction, target=target)
 
 
 def mean_squared_log_error(target, prediction) -> torch.Tensor:
@@ -73,7 +70,7 @@ def mean_squared_log_error(target, prediction) -> torch.Tensor:
         prediction (torch.Tensor): The prediction tensor.
     """
     mle = MeanSquaredLogError()
-    return mle(target, prediction)
+    return mle(preds=prediction, target=target)
 
 
 def mean_absolute_error(target, prediction) -> torch.Tensor:
@@ -85,7 +82,7 @@ def mean_absolute_error(target, prediction) -> torch.Tensor:
         prediction (torch.Tensor): The prediction tensor.
     """
     mae = MeanAbsoluteError()
-    return mae(target, prediction)
+    return mae(preds=prediction, target=target)
 
 
 def _get_ncc_image(target, prediction) -> sitk.Image:


### PR DESCRIPTION
1. I replaced the self-implemented [PSNR](https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio) computation with the one provided [by torchmetric](https://torchmetrics.readthedocs.io/en/stable/image/peak_signal_noise_ratio.html). Main reason; the MAX_I is actually not the same as data_range (even if the original torchmetrics code [suggests so](https://github.com/Lightning-AI/torchmetrics/blob/035e433ce416d82e415d16ba87f8c12cbb74fdef/src/torchmetrics/image/psnr.py#L145))
2. The ordering of torchmetric function call arguments is actually predictions ("preds") and then target ("target"), not the other way around (see torchmetric documentation [SSIM](https://torchmetrics.readthedocs.io/en/stable/image/structural_similarity.html), [MSE](https://torchmetrics.readthedocs.io/en/stable/regression/mean_squared_error.html), [PSNR](https://torchmetrics.readthedocs.io/en/stable/image/peak_signal_noise_ratio.html), [MSLE](https://torchmetrics.readthedocs.io/en/stable/regression/mean_squared_log_error.html), [MAE](https://torchmetrics.readthedocs.io/en/stable/regression/mean_absolute_error.html) or the code directly. e.g [for MSE](https://github.com/Lightning-AI/torchmetrics/blob/035e433ce416d82e415d16ba87f8c12cbb74fdef/src/torchmetrics/regression/mse.py#L75)). The differentiation between what is target and what prediction is probably irrelevant for most metrics (like MSE). However, for PSNR it does play a role. I changed the order for all the torchmetric calls for consitency and used the respective named arguments for clarity.

I did not test the changes for GaNDLF specifically as they are minimal and I tested them for our BraTS repo where they did work and we basically use the same code anyways... 

<!-- Replace ISSUE_NUMBER with the issue that will be auto-linked to close after merging this PR -->
Fixes #ISSUE_NUMBER

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- Use [torchmetrics own PSNR](https://torchmetrics.readthedocs.io/en/stable/image/peak_signal_noise_ratio.html) implementation
- Reorder target and prediction argument as intended by torchmetrics

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide.
- [x] My PR is based from the [current GaNDLF master ](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch-in-github-desktop?platform=windows).
- [ ] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change.
- [ ] Function/class source code documentation added/updated.
- [ ] Code has been [blacked](https://github.com/psf/black#usage) for style consistency.
- [ ] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/mlcommons/GaNDLF/blob/master/GANDLF/version.py).
- [ ] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/mlcommons/GaNDLF/blob/master/pyproject.toml) file.
- [ ] [Usage documentation](https://github.com/mlcommons/GaNDLF/blob/master/docs) has been updated, if appropriate.
- [ ] Tests added or modified to [cover the changes](https://app.codecov.io/gh/mlcommons/GaNDLF); if coverage is reduced, please give explanation.
- [ ] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/mlcommons/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/mlcommons/GaNDLF/blob/devcontainer_build_fix/Dockerfile-CUDA11.6),[3](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-ROCm)].
