### PR TITLE
Using tuples for PSNR data_range not float. Added data_range to psnr_01_eps case (was missing there)

### DIFF
--- a/GANDLF/cli/generate_metrics.py
+++ b/GANDLF/cli/generate_metrics.py
@@ -301,14 +301,14 @@ def generate_metrics_dict(input_csv: str, config: str, outputfile: str = None) -
                 overall_stats_dict[current_subject_id][
                     "psnr_01"
                 ] = peak_signal_noise_ratio(
-                    gt_image_infill, output_infill, data_range=1.0
+                    gt_image_infill, output_infill, data_range=(0,1)
                 ).item()
 
                 # same as above but with epsilon for robustness
                 overall_stats_dict[current_subject_id][
                     "psnr_01_eps"
                 ] = peak_signal_noise_ratio(
-                    gt_image_infill, output_infill, epsilon=sys.float_info.epsilon
+                    gt_image_infill, output_infill, data_range=(0,1), epsilon=sys.float_info.epsilon
                 ).item()
 
     pprint(overall_stats_dict)

--- a/GANDLF/metrics/synthesis.py
+++ b/GANDLF/metrics/synthesis.py
@@ -55,7 +55,7 @@ def peak_signal_noise_ratio(target, prediction, data_range=None, epsilon=None) -
     Args:
         target (torch.Tensor): The target tensor.
         prediction (torch.Tensor): The prediction tensor.
-        data_range (float, optional): If not None, this data range is used as enumerator instead of computing it from the given data. Defaults to None.
+        data_range (tuple, optional): If not None, this data range (min, max) is used as enumerator instead of computing it from the given data. Defaults to None.
         epsilon (float, optional): If not None, this epsilon is added to the denominator of the fraction to avoid infinity as output. Defaults to None.
     """
 
@@ -67,8 +67,9 @@ def peak_signal_noise_ratio(target, prediction, data_range=None, epsilon=None) -
         if data_range == None: #compute data_range like torchmetrics if not given
             min_v = 0 if torch.min(target) > 0 else torch.min(target) #look at this line
             max_v = torch.max(target)
-            data_range = max_v - min_v
-        return 10.0 * torch.log10((data_range ** 2) / (mse + epsilon))
+        else:
+            min_v, max_v = data_range
+        return 10.0 * torch.log10(((max_v-min_v) ** 2) / (mse + epsilon))
 
 
 def mean_squared_log_error(target, prediction) -> torch.Tensor:


### PR DESCRIPTION
Fixes missing 0-1 range for the psnr_01_eps case (synthesis case).

## Proposed Changes
- Use tuple to indicate range (not just an float). This should be more intuitive.
- Added the data_range to the psnr_01_eps case because it was missing there

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide.
- [x] My PR is based from the [current GaNDLF master ](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch-in-github-desktop?platform=windows).
- [x] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change.
- [x] Function/class source code documentation added/updated.
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency.
- [ ] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/mlcommons/GaNDLF/blob/master/GANDLF/version.py).
- [ ] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/mlcommons/GaNDLF/blob/master/pyproject.toml) file.
- [ ] [Usage documentation](https://github.com/mlcommons/GaNDLF/blob/master/docs) has been updated, if appropriate.
- [ ] Tests added or modified to [cover the changes](https://app.codecov.io/gh/mlcommons/GaNDLF); if coverage is reduced, please give explanation.
- [ ] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/mlcommons/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/mlcommons/GaNDLF/blob/devcontainer_build_fix/Dockerfile-CUDA11.6),[3](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-ROCm)].
