### PR TITLE
Added parameter to toggle NCC computation

### DIFF
--- a/GANDLF/cli/generate_metrics.py
+++ b/GANDLF/cli/generate_metrics.py
@@ -253,18 +253,20 @@ def generate_metrics_dict(input_csv: str, config: str, outputfile: str = None) -
             ] = structural_similarity_index(gt_image_infill, output_infill, mask).item()
 
             # ncc metrics
-            overall_stats_dict[current_subject_id]["ncc_mean"] = ncc_mean(
-                gt_image_infill, output_infill
-            )
-            overall_stats_dict[current_subject_id]["ncc_std"] = ncc_std(
-                gt_image_infill, output_infill
-            )
-            overall_stats_dict[current_subject_id]["ncc_max"] = ncc_max(
-                gt_image_infill, output_infill
-            )
-            overall_stats_dict[current_subject_id]["ncc_min"] = ncc_min(
-                gt_image_infill, output_infill
-            )
+            compute_ncc = parameters.get("compute_ncc", True)
+            if compute_ncc:
+                overall_stats_dict[current_subject_id]["ncc_mean"] = ncc_mean(
+                    gt_image_infill, output_infill
+                )
+                overall_stats_dict[current_subject_id]["ncc_std"] = ncc_std(
+                    gt_image_infill, output_infill
+                )
+                overall_stats_dict[current_subject_id]["ncc_max"] = ncc_max(
+                    gt_image_infill, output_infill
+                )
+                overall_stats_dict[current_subject_id]["ncc_min"] = ncc_min(
+                    gt_image_infill, output_infill
+                )
 
             # only voxels that are to be inferred (-> flat array)
             # these are required for mse, psnr, etc.


### PR DESCRIPTION
Introduced a parameter (compute_ncc, defaut=True) that allows to turn off the (time-consuming) computation of the 4 NCC metrics.

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide.
- [x] My PR is based from the [current GaNDLF master ](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch-in-github-desktop?platform=windows).
- [x] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change.
- [ ] Function/class source code documentation added/updated.
- [ ] Code has been [blacked](https://github.com/psf/black#usage) for style consistency.
- [ ] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/mlcommons/GaNDLF/blob/master/GANDLF/version.py).
- [ ] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/mlcommons/GaNDLF/blob/master/pyproject.toml) file.
- [ ] [Usage documentation](https://github.com/mlcommons/GaNDLF/blob/master/docs) has been updated, if appropriate.
- [ ] Tests added or modified to [cover the changes](https://app.codecov.io/gh/mlcommons/GaNDLF); if coverage is reduced, please give explanation.
- [ ] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/mlcommons/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/mlcommons/GaNDLF/blob/devcontainer_build_fix/Dockerfile-CUDA11.6),[3](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-ROCm)].
