### PR TITLE
Fixed model saving when git repo not found 

### DIFF
--- a/GANDLF/utils/modelio.py
+++ b/GANDLF/utils/modelio.py
@@ -155,14 +155,14 @@ def save_model(
     model_dict["parameters"] = params
 
     try:
-        print("DEBUG os.getcwd():", os.getcwd())
+        # this will try to encode the git hash of the current GaNDLF codebase, and reverts to "None" if not found
         model_dict["git_hash"] = (
             subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=os.getcwd())
             .decode("ascii")
             .strip()
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
-        model_dict["git_hash"] = None
+        model_dict["git_hash"] = "None"
 
     torch.save(model_dict, path)
 

--- a/GANDLF/utils/modelio.py
+++ b/GANDLF/utils/modelio.py
@@ -155,8 +155,9 @@ def save_model(
     model_dict["parameters"] = params
 
     try:
+        print("DEBUG os.getcwd():", os.getcwd())
         model_dict["git_hash"] = (
-            subprocess.check_output(["git", "rev-parse", "HEAD"])
+            subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=os.getcwd())
             .decode("ascii")
             .strip()
         )

--- a/GANDLF/utils/modelio.py
+++ b/GANDLF/utils/modelio.py
@@ -161,7 +161,7 @@ def save_model(
             .decode("ascii")
             .strip()
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         model_dict["git_hash"] = None
 
     torch.save(model_dict, path)


### PR DESCRIPTION
<!-- Replace ISSUE_NUMBER with the issue that will be auto-linked to close after merging this PR -->
Fixes #723

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- added another type of exception check during model saving

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide.
- [x] My PR is based from the [current GaNDLF master ](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch-in-github-desktop?platform=windows).
- [x] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change.
- [x] Function/class source code documentation added/updated.
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency.
- [x] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/mlcommons/GaNDLF/blob/master/GANDLF/version.py).
- [x] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/mlcommons/GaNDLF/blob/master/pyproject.toml) file.
- [x] [Usage documentation](https://github.com/mlcommons/GaNDLF/blob/master/docs) has been updated, if appropriate.
- [x] Tests added or modified to [cover the changes](https://app.codecov.io/gh/mlcommons/GaNDLF); if coverage is reduced, please give explanation.
- [x] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/mlcommons/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/mlcommons/GaNDLF/blob/devcontainer_build_fix/Dockerfile-CUDA11.6),[3](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-ROCm)].
