### PR TITLE
Make sure Hugging Face downloads work, better discoverability

### DIFF
--- a/GANDLF/models/modelBase.py
+++ b/GANDLF/models/modelBase.py
@@ -13,8 +13,10 @@ from GANDLF.models.seg_modules.average_pool import (
     GlobalAveragePooling2D,
 )
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class ModelBase(nn.Module):
+
+class ModelBase(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/mlcommons/GaNDLF/", tags=["segmentation", "medical", "pytorch"]):
     """
     This is the base model class that all other architectures will need to derive from
     """


### PR DESCRIPTION
Hi @sarthakpati  and team,

Thanks for this nice work! I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various GaNDLF models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from .models import DenseNet

model = DenseNet(...)

# optionally, one can push a trained model to the hub at the end of training
model.push_to_hub("nielsr/densenet-finetuned-medical-segmentation")

# reload as follows
model = DenseNet.from_pretrained("nielsr/densenet-finetuned-medical-segmentation")
```

Alternatively, if you want a more custom integration with the hub, we also provide methods like [hf_hub_download](https://huggingface.co/docs/huggingface_hub/v0.23.2/en/package_reference/file_download#huggingface_hub.hf_hub_download) (to download a file from the hub, [upload_folder](https://huggingface.co/docs/huggingface_hub/v0.23.2/en/package_reference/hf_api#huggingface_hub.HfApi.upload_folder) and [upload_file](https://huggingface.co/docs/huggingface_hub/v0.23.2/en/package_reference/hf_api#huggingface_hub.HfApi.upload_file)). Those require some more work however to make download stats work.

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub.

Would you be interested in this integration?

Fixes https://github.com/mlcommons/GaNDLF/issues/727

Kind regards,

Niels