### PR TITLE
Fix binary auroc error

### DIFF
--- a/GANDLF/metrics/classification.py
+++ b/GANDLF/metrics/classification.py
@@ -101,14 +101,17 @@ def overall_stats(prediction: torch.Tensor, target: torch.Tensor, params: dict) 
             ),
         }
         for metric_name, calculator in calculators.items():
+            metric_prediction = prediction
+            metric_target = target
             if "auroc" in metric_name:
-                output_metrics[metric_name] = get_output_from_calculator(
-                    predictions_prob, target_wrap, calculator
-                )
-            else:
-                output_metrics[metric_name] = get_output_from_calculator(
-                    prediction, target, calculator
-                )
+                metric_prediction = predictions_prob
+                metric_target = target_wrap
+                if task == "binary":
+                    metric_prediction = predictions_prob[:, 1]
+
+            output_metrics[metric_name] = get_output_from_calculator(
+                metric_prediction, metric_target, calculator
+            )
 
     # metrics that do not need the "average" parameter
     calculators = {


### PR DESCRIPTION
For binary classification, AUROC metric requires a proba just of the class 1, with shape of `(N,)` rather then `(N,C)` as for multiclass.
https://lightning.ai/docs/torchmetrics/stable/classification/auroc.html#binaryauroc
So, right now binary classification AUROCmetric should fail (at least, it always fails for me). We may check why CI tests work as expected btw...

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide has been followed.
- [x] PR is based on the [current GaNDLF master ](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch-in-github-desktop?platform=windows).
- [x] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change.
- ~[ ] Function/class source code documentation added/updated (ensure `typing` is used to provide type hints, including and not limited to using `Optional` if a variable has a pre-defined value).~
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency and linting.
- ~[ ] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/mlcommons/GaNDLF/blob/master/GANDLF/version.py).~
- ~[ ] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/mlcommons/GaNDLF/blob/master/pyproject.toml) file.~
- ~[ ] [Usage documentation](https://github.com/mlcommons/GaNDLF/blob/master/docs) has been updated, if appropriate.~
- [ ] Tests added or modified to [cover the changes](https://app.codecov.io/gh/mlcommons/GaNDLF); if coverage is reduced, please give explanation.
- ~[ ] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/mlcommons/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/mlcommons/GaNDLF/blob/devcontainer_build_fix/Dockerfile-CUDA11.6),[3](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-ROCm)].~
