### PR TITLE
Correct spelling error

### DIFF
--- a/GANDLF/compute/loss_and_metric.py
+++ b/GANDLF/compute/loss_and_metric.py
@@ -37,7 +37,7 @@ def get_metric_output(
         if len(temp) > 1:
             return temp
         else:
-            # TODO: this branch is extremely age case and is buggy.
+            # TODO: this branch is extremely edge case and is buggy.
             #  Overall the case when metric returns a list but of length 1 is very rare. The only case is when
             #  the metric returns Nx.. tensor (i.e. without aggregation by elements) and batch_size==N==1. This branch
             #  would definitely fail for such a metrics like


### PR DESCRIPTION
Fixes #

## Proposed Changes
- minor spelling correction in the comment 

## Checklist

- [X] [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide has been followed.
- [X] PR is based on the [current GaNDLF master ](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch-in-github-desktop?platform=windows).
- [ X] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change.
- [ X] Function/class source code documentation added/updated (ensure `typing` is used to provide type hints, including and not limited to using `Optional` if a variable has a pre-defined value).
- [ X] Code has been [blacked](https://github.com/psf/black#usage) for style consistency and linting.
- [X ] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/mlcommons/GaNDLF/blob/master/GANDLF/version.py).
- [ X] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/mlcommons/GaNDLF/blob/master/pyproject.toml) file.
- [X ] [Usage documentation](https://github.com/mlcommons/GaNDLF/blob/master/docs) has been updated, if appropriate.
- [ X] Tests added or modified to [cover the changes](https://app.codecov.io/gh/mlcommons/GaNDLF); if coverage is reduced, please give explanation.
- [ X] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/mlcommons/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/mlcommons/GaNDLF/blob/devcontainer_build_fix/Dockerfile-CUDA11.6),[3](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-ROCm)].
- [ X] The `logging` library is being used and no `print` statements are left.
